### PR TITLE
Add web service discovery for unauthenticated HTTP(S) URLs

### DIFF
--- a/cmd/gcp_service_discovery/main.go
+++ b/cmd/gcp_service_discovery/main.go
@@ -12,10 +12,11 @@ package main
 
 import (
 	"fmt"
-	flag "github.com/spf13/pflag"
 	"log"
 	"os"
 	"time"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/m-lab/gcp-service-discovery/aeflex"
 	"github.com/m-lab/gcp-service-discovery/discovery"
@@ -54,6 +55,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	// TODO(p2, soltesz): add timeout parameter to aeflex and gke NewSourceFactory.
+
 	// Allocate every relevant source factories.
 	if *aefTarget != "" {
 		// Allocate a new authenticated client for App Engine API.
@@ -65,7 +68,7 @@ func main() {
 	}
 	for i := range httpSources {
 		// Allocate a new client for downloading an HTTP(S) source.
-		factories = append(factories, web.NewSourceFactory(httpSources[i], httpTargets[i]))
+		factories = append(factories, web.NewSourceFactory(httpSources[i], httpTargets[i], *refresh))
 	}
 
 	// Verify that there is at least one source factory allocated before continuing.

--- a/web/web.go
+++ b/web/web.go
@@ -1,3 +1,4 @@
+// web implements service discovery for generic HTTP or HTTPS URLs.
 package web
 
 import (

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,73 @@
+package web
+
+import (
+	"github.com/m-lab/gcp-service-discovery/discovery"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// Factory stores information needed to create new Source instances.
+type Factory struct {
+	// The configuration source, as an http or https URL.
+	srcUrl string
+
+	// The output filename.
+	dstFile string
+}
+
+// NewSourceFactory returns a new Factory object that can create new Web Sources.
+func NewSourceFactory(source, target string) *Factory {
+	return &Factory{
+		srcUrl:  source,
+		dstFile: target,
+	}
+}
+
+// Create returns a discovery.Source initialized with an http.Client ready for
+// Collection.
+func (f *Factory) Create() (discovery.Source, error) {
+	client := http.Client{
+		Timeout: time.Minute,
+	}
+	source := &Source{
+		factory: *f,
+		client:  client,
+	}
+
+	return source, nil
+}
+
+// Source caches information collected from the GCE, GKE, and K8S APIs during
+// target discovery.
+type Source struct {
+	factory Factory
+	client  http.Client
+	data    []byte
+}
+
+// Saves collected targets to the given filename.
+func (source *Source) Save() error {
+	// Save targets to output file.
+	err := ioutil.WriteFile(source.factory.dstFile, source.data, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Collect uses http.Client library to download a file from an HTTP(S) url.
+func (source *Source) Collect() error {
+	resp, err := source.client.Get(source.factory.srcUrl)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	source.data = data
+	return nil
+}

--- a/web/web.go
+++ b/web/web.go
@@ -40,11 +40,10 @@ func (f *Factory) Create() (discovery.Source, error) {
 		factory: *f,
 		client:  client,
 	}
-
 	return source, nil
 }
 
-// Source caches information collected from the web Source after collection.
+// Source caches data collected from the web.
 type Source struct {
 	// factory is a copy of the original instance that created this source.
 	factory Factory


### PR DESCRIPTION
This change adds support for downloading unauthenticated HTTP(S) URLs.

This change supports distributing prometheus target configuration files generated by mlabconfig.py to running prometheus deployments that use file-based service discovery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/4)
<!-- Reviewable:end -->
