### PR TITLE
Use safefile.WriteFile for atomic writes.

### DIFF
--- a/aeflex/aeflex.go
+++ b/aeflex/aeflex.go
@@ -4,12 +4,12 @@ package aeflex
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"regexp"
 	"strings"
 
+	"github.com/dchest/safefile"
 	"github.com/kr/pretty"
 
 	"golang.org/x/oauth2"
@@ -100,7 +100,8 @@ func (source *Source) Save() error {
 	}
 
 	// Save targets to output file.
-	err = ioutil.WriteFile(source.factory.filename, data, 0644)
+	log.Printf("Saving: %s", source.factory.filename)
+	err = safefile.WriteFile(source.factory.filename, data, 0644)
 	if err != nil {
 		log.Printf("Failed to write %s: %s", source.factory.filename, err)
 		return err

--- a/gke/gke.go
+++ b/gke/gke.go
@@ -6,10 +6,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 
+	"github.com/dchest/safefile"
 	"github.com/kr/pretty"
 
 	"golang.org/x/oauth2"
@@ -107,7 +107,8 @@ func (source *Source) Save() error {
 	}
 
 	// Save targets to output file.
-	err = ioutil.WriteFile(source.factory.filename, data, 0644)
+	log.Printf("Saving: %s", source.factory.filename)
+	err = safefile.WriteFile(source.factory.filename, data, 0644)
 	if err != nil {
 		log.Printf("Failed to write %s: %s", source.factory.filename, err)
 		return err

--- a/web/web.go
+++ b/web/web.go
@@ -3,9 +3,11 @@ package web
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
 	"time"
 
+	"github.com/dchest/safefile"
 	"github.com/m-lab/gcp-service-discovery/discovery"
 )
 
@@ -58,7 +60,8 @@ type Source struct {
 // Saves collected targets to the given filename.
 func (source *Source) Save() error {
 	// Save targets to output file.
-	err := ioutil.WriteFile(source.factory.dstFile, source.data, 0644)
+	log.Printf("Saving: %s", source.factory.dstFile)
+	err := safefile.WriteFile(source.factory.dstFile, source.data, 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This change uses atomic writes for saving output files.

Prometheus watches file-service-discovery directories using inotify. And, `ioutil.WriteFile` is not atomic. As a result, prometheus was trying to read files at the same time they were being written, resulting in sporadic error messages from prometheus like:

```
level=error msg="Error reading file \"/aeflex-targets/aeflex.json\": unexpected end of JSON input" source="file.go:197" 
```

This change uses the `safefile` package to write files atomically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/5)
<!-- Reviewable:end -->
