### PR TITLE
Check for AutomaticScaling or ManualScaling before calculating instances

### DIFF
--- a/aeflex/aeflex.go
+++ b/aeflex/aeflex.go
@@ -157,12 +157,18 @@ func (source *Source) Collect() error {
 //       ]
 //   }
 func (source *Source) getLabels(service *appengine.Service, version *appengine.Version, instance *appengine.Instance) map[string]interface{} {
+	var instances int64
+	if version.AutomaticScaling != nil {
+		instances = version.AutomaticScaling.MaxTotalInstances
+	} else if version.ManualScaling != nil {
+		instances = version.ManualScaling.Instances
+	}
 	labels := map[string]string{
 		aefLabelProject:      source.factory.project,
 		aefLabelService:      service.Id,
 		aefLabelVersion:      version.Id,
 		aefLabelInstance:     instance.Id,
-		aefMaxTotalInstances: fmt.Sprintf("%d", version.AutomaticScaling.MaxTotalInstances),
+		aefMaxTotalInstances: fmt.Sprintf("%d", instances),
 		aefVmDebugEnabled:    fmt.Sprintf("%t", instance.VmDebugEnabled),
 	}
 	if strings.HasSuffix(version.Network.ForwardedPorts[0], "/udp") {


### PR DESCRIPTION
The original version of gcp-service-discovery did not check whether `AutomaticScaling` was nil, which it is when `ManualScaling` is enabled.

We've always used automatic scaling for app engine apps until recetly. This change checks both values before calculating instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/8)
<!-- Reviewable:end -->
