### PR TITLE
Add basic travis build check using docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+- '1.11'
+
+# Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
+go_import_path: github.com/m-lab/gcp-service-discovery
+
+
+script:
+# Verify that docker image builds.
+- docker build -t gcp-service-discovery .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM golang:1.8
+FROM golang:1.11 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
 RUN go get -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery
-ENTRYPOINT ["/go/bin/gcp_service_discovery"]
+
+# Now copy the built image into the minimal base image
+FROM alpine
+COPY --from=build /go/bin/gcp_service_discovery /
+WORKDIR /
+ENTRYPOINT ["/gcp_service_discovery"]


### PR DESCRIPTION
gcp-service-discovery should be updated with unit tests throughout. As a minimal incremental step, this change adds a travis file to build the docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/15)
<!-- Reviewable:end -->
