### PR TITLE
Add new discovery manager & support unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,19 @@ go:
 # Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
 go_import_path: github.com/m-lab/gcp-service-discovery
 
+before_install:
+- go get github.com/mattn/goveralls
+- go get github.com/wadey/gocovmerge
 
 script:
-# Verify that docker image builds.
+# Run query "unit tests".
+- for module in manager ; do
+    go test -v -short -covermode=count -coverprofile=${module}.cov github.com/m-lab/gcp-service-discovery/${module} ;
+  done
+
+# Coveralls
+- $HOME/gopath/bin/gocovmerge *.cov > merge.cov
+- $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
+
+# Verify that the docker image builds.
 - docker build -t gcp-service-discovery .

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,5 +1,11 @@
-// discovery defines generic interfaces for service discovery.
+// Package discovery defines interfaces for service discovery.
 package discovery
+
+import (
+	"context"
+)
+
+//- Legacy Interfaces -//
 
 // Source defines the interface for collecting targets from various
 // services. New services should implement this interface.
@@ -15,4 +21,26 @@ type Source interface {
 type Factory interface {
 	// Create creates a new Source ready for collection.
 	Create() (Source, error)
+}
+
+//- New Interfaces -//
+
+// Service collects target configurations for the discovery Manager.
+type Service interface {
+	// Discover identifies and returns StaticConfig targets from a third-party
+	// service.
+	Discover(ctx context.Context) ([]StaticConfig, error)
+}
+
+// StaticConfig represents a set of targets and associated labels. StaticConfig
+// serializes to the "file_sd_config" format.
+// https://prometheus.io/docs/prometheus/latest/configuration/configuration/#<file_sd_config>
+type StaticConfig struct {
+	// Targets is a list of targets identified by a label set. Each target is
+	// uniquely identifiable in the group by its address label.
+	Targets []string `json:"targets"`
+
+	// Labels is a set of keys/values that are common across all targets in the
+	// StaticConfig.
+	Labels map[string]string `json:"labels,omitempty"`
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -1,0 +1,83 @@
+// Package manager manages and runs service discovery and saves target
+// configuration files.
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/dchest/safefile"
+	"github.com/m-lab/gcp-service-discovery/discovery"
+	"github.com/m-lab/go/rtx"
+)
+
+// Manager foobar.
+type Manager struct {
+	services []discovery.Service
+	output   []string
+	Timeout  time.Duration
+}
+
+// NewManager generates
+func NewManager(timeout time.Duration) *Manager {
+	return &Manager{Timeout: timeout}
+}
+
+// Register accepts a new thing for output.
+func (m *Manager) Register(s discovery.Service, output string) {
+	m.services = append(m.services, s)
+	m.output = append(m.output, output)
+	return
+}
+
+// Count returns the number of services registered.
+func (m *Manager) Count() int {
+	return len(m.services)
+}
+
+// Run collects all services every interval period.
+func (m *Manager) Run(ctx context.Context, interval time.Duration) {
+	tick := time.Tick(interval)
+	for {
+		// TODO: add waitgroup and run discovery in parallel.
+		for i := range m.services {
+
+			ctx2, cancel := context.WithTimeout(context.Background(), m.Timeout)
+			configs, err := m.services[i].Discover(ctx2)
+			cancel()
+			if err != nil {
+				log.Printf("Error: %T: %s", m.services[i], err)
+				continue
+			}
+			err = writeConfigToFile(configs, m.output[i])
+			if err != nil {
+				log.Printf("Error: %s: %s", m.output[i], err)
+			}
+		}
+
+		// Wait for ticker or exit when ctx is closed.
+		select {
+		case <-tick:
+			continue
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// writeConfigToFile serializes and writes the given configs as JSON to the output filename.
+func writeConfigToFile(configs []discovery.StaticConfig, filename string) error {
+	// Convert to JSON.
+	data, err := json.MarshalIndent(configs, "", "    ")
+	rtx.Must(err, "Failed to marshal StaticConfig")
+
+	// Write to file.
+	err = safefile.WriteFile(filename, data, 0644)
+	if err != nil {
+		log.Printf("Failed to write %s: %s", filename, err)
+		return err
+	}
+	return nil
+}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,89 @@
+// Package manager manages and runs service discovery and saves target
+// configuration files.
+package manager
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m-lab/gcp-service-discovery/discovery"
+)
+
+type fakeLiteral struct{}
+
+func (f *fakeLiteral) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
+	return []discovery.StaticConfig{
+		{Targets: []string{"output"}, Labels: map[string]string{"key": "value"}},
+	}, nil
+}
+
+type fakeTimeout struct{}
+
+func (f *fakeTimeout) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
+	<-ctx.Done()
+	return []discovery.StaticConfig{}, nil
+}
+
+type fakeFailure struct{}
+
+func (f *fakeFailure) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
+	return nil, fmt.Errorf("Failed to discover")
+}
+
+func TestManager_Run(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  discovery.Service
+		output   string
+		timeout  time.Duration
+		ctx      context.Context
+		interval time.Duration
+	}{
+		{
+			name:    "success",
+			service: &fakeLiteral{},
+			output:  "foo.txt",
+			timeout: time.Minute,
+		},
+		{
+			name:    "failure-cannot-write",
+			service: &fakeLiteral{},
+			output:  "/path/does/not/exist/foo.txt",
+			timeout: time.Minute,
+		},
+		{
+			name:    "failure-timeout",
+			service: &fakeTimeout{},
+			output:  "foo.txt",
+			timeout: time.Second,
+		},
+		{
+			name:    "failure-to-discovery",
+			service: &fakeFailure{},
+			timeout: time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			m := NewManager(tt.timeout)
+			m.Register(tt.service, tt.output)
+			if m.Count() != 1 {
+				t.Errorf("Wrong manager count; got %q, want 1", m.Count())
+				return
+			}
+
+			go func() {
+				time.Sleep(time.Second)
+				// Cancel context ~1s after running.
+				cancel()
+			}()
+
+			m.Run(ctx, time.Second/2)
+		})
+	}
+}


### PR DESCRIPTION
This change adds a new discovery manager implementation that will ultimately replace the "factory" and "source" logic in the current web, gke, and aeflex packages.

This change is the first of 5 that add unit testing to all packages and improving the interface for new discovery services.