### PR TITLE
Update web to use new discovery.Service interface

### DIFF
--- a/cmd/gcp_service_discovery/main.go
+++ b/cmd/gcp_service_discovery/main.go
@@ -91,9 +91,11 @@ func main() {
 		log.Fatal(http.ListenAndServe(":9373", nil))
 	}()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		// Run discovery forever.
-		manager.Run(context.Background(), *refresh)
+		manager.Run(ctx, *refresh)
 	}()
 
 	// Only sleep as long as we need to, before starting a new iteration.

--- a/web/web.go
+++ b/web/web.go
@@ -29,10 +29,9 @@ type Service struct {
 // should be an HTTP(S) URL to a file whose contents are a JSON formatted
 // Prometheus static_config.
 func NewService(srcURL string) *Service {
-	s := &Service{
+	return &Service{
 		srcURL: srcURL,
 	}
-	return s
 }
 
 // Discover downloads the source URL provided at service creation time.

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -66,6 +66,11 @@ func TestSource_Discover(t *testing.T) {
 			readAllFail: true,
 			wantErr:     true,
 		},
+		{
+			name:    "failure-url-is-invalid",
+			badURL:  ":/this-is-an-invalid-url",
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -88,7 +93,7 @@ func TestSource_Discover(t *testing.T) {
 			} else {
 				readAll = ioutil.ReadAll
 			}
-			srv := NewService(url, 5*time.Second)
+			srv := NewService(url)
 			got, err := srv.Discover(context.Background())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Discover() error = %v, wantErr %v", err, tt.wantErr)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,102 @@
+// web implements service discovery for generic HTTP or HTTPS URLs.
+package web
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/m-lab/gcp-service-discovery/discovery"
+)
+
+func TestSource_Discover(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		target      string
+		timeout     time.Duration
+		fileContent string
+		want        []discovery.StaticConfig
+		badURL      string
+		statusCode  int
+		readAllFail bool
+		wantErr     bool
+	}{
+		{
+			name: "success",
+			fileContent: `
+			[
+				{
+					"targets": ["okay"],
+					"labels": {"a":"b"}
+				}
+			]`,
+			statusCode: http.StatusOK,
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"okay"},
+					Labels:  map[string]string{"a": "b"},
+				},
+			},
+		},
+		{
+			name:    "failure-bad-url",
+			badURL:  "http://badurl:100",
+			wantErr: true,
+		},
+		{
+			name:       "failure-bad-http-status",
+			statusCode: http.StatusNotFound,
+			wantErr:    true,
+		},
+		{
+			name:       "failure-bad-file-content",
+			statusCode: http.StatusOK,
+			wantErr:    true,
+		},
+		{
+			name:        "failure-readall-fails",
+			statusCode:  http.StatusOK,
+			readAllFail: true,
+			wantErr:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.statusCode)
+					fmt.Fprintln(w, tt.fileContent)
+				}),
+			)
+			defer ts.Close()
+
+			url := ts.URL
+			if tt.badURL != "" {
+				url = tt.badURL
+			}
+			if tt.readAllFail {
+				readAll = func(r io.Reader) ([]byte, error) {
+					return nil, fmt.Errorf("Fake Read Error")
+				}
+			} else {
+				readAll = ioutil.ReadAll
+			}
+			srv := NewService(url, 5*time.Second)
+			got, err := srv.Discover(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Source.Discover() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Source.Discover() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change is a continuation of https://github.com/m-lab/gcp-service-discovery/issues/17 for adding unit tests to all gcp-service-discovery methods.

This change updates the web package to use the new `discovery.Service` interface and updates the gcp_service_discovery command to use the new `discovery.Manager` for web services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/18)
<!-- Reviewable:end -->
