### PR TITLE
Add unit tests for aeflex service discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,9 @@ before_install:
 
 script:
 # Run query "unit tests".
-- for module in discovery web aeflex ; do
-    go test -v -short -covermode=count -coverprofile=${module}.cov github.com/m-lab/gcp-service-discovery/${module} ;
-  done
+- go test -v -short -covermode=count -coverprofile=merge.cov ./...
 
-# Coveralls
-- $HOME/gopath/bin/gocovmerge *.cov > merge.cov
+# Publish to coveralls
 - $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
 
 # Verify that the docker image builds.

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 script:
 # Run query "unit tests".
-- for module in discovery ; do
+- for module in discovery web aeflex ; do
     go test -v -short -covermode=count -coverprofile=${module}.cov github.com/m-lab/gcp-service-discovery/${module} ;
   done
 

--- a/aeflex/aeflex.go
+++ b/aeflex/aeflex.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"regexp"
 	"strings"
 
@@ -34,9 +33,7 @@ var (
 	defaultScopes = []string{appengine.CloudPlatformScope, appengine.AppengineAdminScope}
 
 	// newAppengineClient allocates a new AppEngine client. The indirection facilitates testing.
-	newAppengineClient = func(client *http.Client) (*appengine.APIService, error) {
-		return appengine.New(client)
-	}
+	newAppengineClient = appengine.New
 )
 
 var (
@@ -98,8 +95,8 @@ type Service struct {
 	api iface.AppAPI
 }
 
-// NewService returns a discovery.Service initialized with authenticated clients for
-// App Engine Admin API, ready for Collection.
+// NewService returns a Service initialized with authenticated clients for
+// App Engine Admin API. The Service implements the discovery.Service interface.
 func NewService(project string) (*Service, error) {
 	source := &Service{
 		project: project,

--- a/aeflex/aeflex.go
+++ b/aeflex/aeflex.go
@@ -2,19 +2,17 @@
 package aeflex
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"regexp"
 	"strings"
 
-	"github.com/dchest/safefile"
-	"github.com/kr/pretty"
-
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
+	"github.com/m-lab/gcp-service-discovery/aeflex/iface"
 	"github.com/m-lab/gcp-service-discovery/discovery"
 	appengine "google.golang.org/api/appengine/v1"
 
@@ -29,21 +27,17 @@ const (
 	aefLabelInstance     = aefLabel + "instance"
 	aefLabelPublicProto  = aefLabel + "public_protocol"
 	aefMaxTotalInstances = aefLabel + "max_total_instances"
-	aefVmDebugEnabled    = aefLabel + "vm_debug_enabled"
+	aefVMDebugEnabled    = aefLabel + "vm_debug_enabled"
 )
 
 var (
 	defaultScopes = []string{appengine.CloudPlatformScope, appengine.AppengineAdminScope}
+
+	// newAppengineClient allocates a new AppEngine client. The indirection facilitates testing.
+	newAppengineClient = func(client *http.Client) (*appengine.APIService, error) {
+		return appengine.New(client)
+	}
 )
-
-// Factory stores information needed to create new Source instances.
-type Factory struct {
-	// The GCP project id.
-	project string
-
-	// The output filename.
-	filename string
-}
 
 var (
 	// ServiceCount is the current number of AEFlex services.
@@ -94,182 +88,83 @@ func init() {
 	prometheus.MustRegister(InstanceCount)
 }
 
-// NewSourceFactory returns a new Factory object that can create new App Engine
-// Flex Sources.
-func NewSourceFactory(project, filename string) *Factory {
-	return &Factory{
-		project:  project,
-		filename: filename,
-	}
+// Service caches information collected from the App Engine Admin API during target discovery.
+type Service struct {
+	project string
+
+	// targets collects found targets.
+	targets []discovery.StaticConfig
+
+	api iface.AppAPI
 }
 
-// Create returns a discovery.Source initialized with authenticated clients for
+// NewService returns a discovery.Service initialized with authenticated clients for
 // App Engine Admin API, ready for Collection.
-func (f *Factory) Create() (discovery.Source, error) {
-	source := &Source{
-		factory: *f,
+func NewService(project string) (*Service, error) {
+	source := &Service{
+		project: project,
 	}
-	var err error
 	// Create a new authenticated HTTP client.
-	source.client, err = google.DefaultClient(oauth2.NoContext, defaultScopes...)
+	client, err := google.DefaultClient(oauth2.NoContext, defaultScopes...)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up AppEngine client: %s", err)
 	}
-
 	// Create a new AppEngine service instance.
-	source.apis, err = appengine.New(source.client)
+	aec, err := newAppengineClient(client)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up AppEngine client: %s", err)
 	}
-
+	source.api = iface.NewAppAPI(source.project, aec)
 	return source, nil
 }
 
-// Source caches information collected from the App Engine Admin API during target discovery.
-type Source struct {
-	// factory is a copy of the original instance that created this source.
-	factory Factory
-
-	// client caches an http client authenticated for access to GCP APIs.
-	client *http.Client
-
-	// apis is the entry point to all AEFlex services.
-	apis *appengine.APIService
-
-	// targets collects found targets.
-	targets []interface{}
-}
-
-// Save writes the content of the the collected set of targets.
-func (source *Source) Save() error {
-	// Convert to JSON.
-	data, err := json.MarshalIndent(source.targets, "", "    ")
-	if err != nil {
-		log.Printf("Failed to Marshal JSON: %s", err)
-		log.Printf("Pretty data: %s", pretty.Sprint(source.targets))
-		return err
-	}
-
-	// Save targets to output file.
-	log.Printf("Saving: %s", source.factory.filename)
-	err = safefile.WriteFile(source.factory.filename, data, 0644)
-	if err != nil {
-		log.Printf("Failed to write %s: %s", source.factory.filename, err)
-		return err
-	}
-	return nil
-}
-
-// Collect contacts the App Engine Admin API to to check every service, and
+// Discover contacts the App Engine Admin API to to check every service, and
 // every serving version. Collect saves every AppEngine Flexible Environments
 // VMs that is in a RUNNING and SERVING state.
-func (source *Source) Collect() error {
-	// Allocate space for the list of targets.
-	source.targets = make([]interface{}, 0)
-
-	s := source.apis.Apps.Services.List(source.factory.project)
+func (source *Service) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
 	// List all services.
 	services := 0
-	err := s.Pages(nil, func(listSvc *appengine.ListServicesResponse) error {
-		services += len(listSvc.Services)
-		for _, service := range listSvc.Services {
-			// List all versions of each service.
-			v := source.apis.Apps.Services.Versions.List(source.factory.project, service.Id)
-			versions := 0
-			active := 0
-			inactive := 0
-			err := v.Pages(nil, func(listVer *appengine.ListVersionsResponse) error {
-				versions += len(listVer.Versions)
-				err := source.handleVersions(listVer, service, &active, &inactive)
-				return err
-			})
-			log.Println(service.Name, "versions:", versions, "active:", active, "inactive:", inactive)
-			VersionCount.WithLabelValues(service.Id).Set(float64(versions))
-			InstanceCount.WithLabelValues(service.Id, "true").Set(float64(active))
-			InstanceCount.WithLabelValues(service.Id, "false").Set(float64(inactive))
-			if err != nil {
-				return err
+	err := source.api.ServicesPages(
+		ctx, func(listSvc *appengine.ListServicesResponse) error {
+			services += len(listSvc.Services)
+			for _, service := range listSvc.Services {
+				err := source.discoverVersions(ctx, service)
+				if err != nil {
+					return err
+				}
 			}
-		}
-		return nil
-	})
+			return nil
+		})
 	ServiceCount.Set(float64(services))
+	if err != nil {
+		return nil, err
+	}
 	// TODO(p2, soltesz): collect and report metrics about number of API calls.
 	// TODO(p2, soltesz): consider using goroutines to speed up collection.
+	return source.targets, nil
+}
+
+func (source *Service) discoverVersions(ctx context.Context, service *appengine.Service) error {
+	// List all versions of each service.
+	versions := 0
+	active := 0
+	inactive := 0
+	err := source.api.VersionsPages(
+		ctx, service.Id, func(listVer *appengine.ListVersionsResponse) error {
+			versions += len(listVer.Versions)
+			return source.handleVersions(ctx, listVer, service, &active, &inactive)
+		})
+	log.Println(service.Name, "versions:", versions, "active:", active, "inactive:", inactive)
+	VersionCount.WithLabelValues(service.Id).Set(float64(versions))
+	InstanceCount.WithLabelValues(service.Id, "true").Set(float64(active))
+	InstanceCount.WithLabelValues(service.Id, "false").Set(float64(inactive))
 	return err
 }
 
-// getLabels creates a target configuration for a prometheus service discovery
-// file. The given service version should have a "SERVING" status, the instance
-// should be in a "RUNNING" state and have at least one forwarded port.
-//
-// In serialized form, the label set look like:
-//   {
-//       "labels": {
-//           "__aef_instance": "aef-etl--parser-20170418t195100-abcd",
-//           "__aef_max_total_instances": "20",
-//           "__aef_project": "mlab-sandbox",
-//           "__aef_public_protocol": "tcp",
-//           "__aef_service": "etl-parser",
-//           "__aef_version": "20170418t195100",
-//           "__aef_vm_debug_enabled": "true"
-//       },
-//       "targets": [
-//           "104.196.220.184:9090"
-//       ]
-//   }
-func (source *Source) getLabels(
-	service *appengine.Service, version *appengine.Version,
-	instance *appengine.Instance) map[string]interface{} {
-	var instances int64
-	if version.AutomaticScaling != nil {
-		instances = version.AutomaticScaling.MaxTotalInstances
-	} else if version.ManualScaling != nil {
-		instances = version.ManualScaling.Instances
-	}
-	labels := map[string]string{
-		aefLabelProject:      source.factory.project,
-		aefLabelService:      service.Id,
-		aefLabelVersion:      version.Id,
-		aefLabelInstance:     instance.Id,
-		aefMaxTotalInstances: fmt.Sprintf("%d", instances),
-		aefVmDebugEnabled:    fmt.Sprintf("%t", instance.VmDebugEnabled),
-	}
-	if strings.HasSuffix(version.Network.ForwardedPorts[0], "/udp") {
-		labels[aefLabelPublicProto] = "udp"
-	} else if strings.HasSuffix(version.Network.ForwardedPorts[0], "/tcp") {
-		labels[aefLabelPublicProto] = "tcp"
-	} else {
-		labels[aefLabelPublicProto] = "both"
-	}
-
-	// TODO(dev): collect max resource sizes: cpu, memory, disk.
-	//   Resources.Cpu
-	//   Resources.DiskGb
-	//   Resources.MemoryGb
-	//   Resources.Volumes[0].Name
-	//   Resources.Volumes[0].SizeGb
-	//   Resources.Volumes[0].VolumeType
-
-	// TODO: do we need to support multiple forwarded ports? How to choose?
-	// Extract target address in the form of the VM public IP and forwarded port.
-	re := regexp.MustCompile("([0-9]+)(/.*)")
-	port := re.ReplaceAllString(version.Network.ForwardedPorts[0], "$1")
-	targets := []string{fmt.Sprintf("%s:%s", instance.VmIp, port)}
-
-	// Construct a record for the Prometheus file service discovery format.
-	// https://prometheus.io/docs/operating/configuration/#<file_sd_config>
-	values := map[string]interface{}{
-		"labels":  labels,
-		"targets": targets,
-	}
-	return values
-}
-
-// handles each version returned by an AppEngine Versions.List.
-func (source *Source) handleVersions(
-	listVer *appengine.ListVersionsResponse, service *appengine.Service,
-	active *int, inactive *int) error {
+// handleVersions checks every instance for each AppEngine version.
+func (source *Service) handleVersions(
+	ctx context.Context, listVer *appengine.ListVersionsResponse,
+	service *appengine.Service, active *int, inactive *int) error {
 
 	for _, version := range listVer.Versions {
 		// We can only monitor instances that are running.
@@ -282,9 +177,8 @@ func (source *Source) handleVersions(
 		_, shouldMonitor := service.Split.Allocations[version.Id]
 
 		// List instances associated with each service version.
-		err := source.apis.Apps.Services.Versions.Instances.List(
-			source.factory.project, service.Id, version.Id).Pages(
-			nil, func(listInst *appengine.ListInstancesResponse) error {
+		err := source.api.InstancesPages(
+			ctx, service.Id, version.Id, func(listInst *appengine.ListInstancesResponse) error {
 				found, err := source.handleInstances(listInst, service, version, shouldMonitor)
 				if shouldMonitor {
 					*active += found
@@ -300,12 +194,12 @@ func (source *Source) handleVersions(
 	return nil
 }
 
-// handleInstances checks each instance returned by AppEngine Versions.List and
+// handleInstances checks each instance in the given instance list and
 // returns the total number of VMs found that *could* be monitored. However,
-// when shouldMonitor is false, the Source targets list is not updated. This
+// when shouldMonitor is false, the Service targets list is not updated. This
 // is helpful for situations where we want to count running instances without
 // monitoring them.
-func (source *Source) handleInstances(
+func (source *Service) handleInstances(
 	listInst *appengine.ListInstancesResponse, service *appengine.Service,
 	version *appengine.Version, shouldMonitor bool) (int, error) {
 	found := 0
@@ -333,4 +227,70 @@ func (source *Source) handleInstances(
 		}
 	}
 	return found, nil
+}
+
+// getLabels creates a target configuration for a prometheus service discovery
+// file. The given service version should have a "SERVING" status, the instance
+// should be in a "RUNNING" state and have at least one forwarded port.
+//
+// In serialized form, the label set look like:
+//   {
+//       "labels": {
+//           "__aef_instance": "aef-etl--parser-20170418t195100-abcd",
+//           "__aef_max_total_instances": "20",
+//           "__aef_project": "mlab-sandbox",
+//           "__aef_public_protocol": "tcp",
+//           "__aef_service": "etl-parser",
+//           "__aef_version": "20170418t195100",
+//           "__aef_vm_debug_enabled": "true"
+//       },
+//       "targets": [
+//           "104.196.220.184:9090"
+//       ]
+//   }
+func (source *Service) getLabels(
+	service *appengine.Service, version *appengine.Version,
+	instance *appengine.Instance) discovery.StaticConfig {
+	var instances int64
+	if version.AutomaticScaling != nil {
+		instances = version.AutomaticScaling.MaxTotalInstances
+	} else if version.ManualScaling != nil {
+		instances = version.ManualScaling.Instances
+	}
+	labels := map[string]string{
+		aefLabelProject:      source.project,
+		aefLabelService:      service.Id,
+		aefLabelVersion:      version.Id,
+		aefLabelInstance:     instance.Id,
+		aefMaxTotalInstances: fmt.Sprintf("%d", instances),
+		aefVMDebugEnabled:    fmt.Sprintf("%t", instance.VmDebugEnabled),
+	}
+	if strings.HasSuffix(version.Network.ForwardedPorts[0], "/udp") {
+		labels[aefLabelPublicProto] = "udp"
+	} else if strings.HasSuffix(version.Network.ForwardedPorts[0], "/tcp") {
+		labels[aefLabelPublicProto] = "tcp"
+	} else {
+		labels[aefLabelPublicProto] = "both"
+	}
+
+	// TODO(dev): collect max resource sizes: cpu, memory, disk.
+	//   Resources.Cpu
+	//   Resources.DiskGb
+	//   Resources.MemoryGb
+	//   Resources.Volumes[0].Name
+	//   Resources.Volumes[0].SizeGb
+	//   Resources.Volumes[0].VolumeType
+
+	// TODO: do we need to support multiple forwarded ports? How to choose?
+	// Extract target address in the form of the VM public IP and forwarded port.
+	re := regexp.MustCompile("([0-9]+)(/.*)")
+	port := re.ReplaceAllString(version.Network.ForwardedPorts[0], "$1")
+
+	values := discovery.StaticConfig{
+		Targets: []string{fmt.Sprintf("%s:%s", instance.VmIp, port)},
+		// Construct a record for the Prometheus file service discovery format.
+		// https://prometheus.io/docs/operating/configuration/#<file_sd_config>
+		Labels: labels,
+	}
+	return values
 }

--- a/aeflex/aeflex_test.go
+++ b/aeflex/aeflex_test.go
@@ -1,0 +1,338 @@
+package aeflex
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/m-lab/gcp-service-discovery/aeflex/iface"
+	"github.com/m-lab/gcp-service-discovery/discovery"
+	appengine "google.golang.org/api/appengine/v1"
+)
+
+type fakeAppAPIImpl struct {
+	services       []*appengine.Service
+	versions       []*appengine.Version
+	instances      []*appengine.Instance
+	servicesError  error
+	versionsError  error
+	instancesError error
+}
+
+func (api *fakeAppAPIImpl) ServicesPages(
+	ctx context.Context, f func(listVer *appengine.ListServicesResponse) error) error {
+	if api.servicesError != nil {
+		return api.servicesError
+	}
+	return f(&appengine.ListServicesResponse{Services: api.services})
+}
+
+func (api *fakeAppAPIImpl) VersionsPages(
+	ctx context.Context, serviceID string,
+	f func(listVer *appengine.ListVersionsResponse) error) error {
+	if api.versionsError != nil {
+		return api.versionsError
+	}
+	return f(&appengine.ListVersionsResponse{Versions: api.versions})
+}
+
+func (api *fakeAppAPIImpl) InstancesPages(
+	ctx context.Context, serviceID, versionID string,
+	f func(listInst *appengine.ListInstancesResponse) error) error {
+	if api.instancesError != nil {
+		return api.instancesError
+	}
+	return f(&appengine.ListInstancesResponse{Instances: api.instances})
+}
+
+func TestService_Discover(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		targets []discovery.StaticConfig
+		api     iface.AppAPI
+		ctx     context.Context
+		want    []discovery.StaticConfig
+		wantErr bool
+	}{
+		{
+			name:    "failure-instances",
+			project: "fake-project",
+			api: &fakeAppAPIImpl{
+				services: []*appengine.Service{
+					&appengine.Service{
+						Id: "fake-service-name",
+						Split: &appengine.TrafficSplit{
+							Allocations: map[string]float64{
+								"20181027t210126-active": 1.0,
+							},
+						},
+					},
+				},
+				versions: []*appengine.Version{
+					// Regular version.
+					&appengine.Version{
+						Id:            "20181027t210126-active",
+						ServingStatus: "SERVING",
+					},
+				},
+				instancesError: fmt.Errorf("failing to list instances."),
+			},
+			wantErr: true,
+		},
+		{
+			name:    "success-udp-manual",
+			project: "fake-project",
+			api: &fakeAppAPIImpl{
+				services: []*appengine.Service{
+					&appengine.Service{
+						Id: "fake-service-name",
+						Split: &appengine.TrafficSplit{
+							Allocations: map[string]float64{
+								"20181027t210126-active": 1.0,
+							},
+						},
+					},
+				},
+				versions: []*appengine.Version{
+					// Regular version.
+					&appengine.Version{
+						Id:            "20181027t210126-active",
+						ServingStatus: "SERVING",
+						Network: &appengine.Network{
+							ForwardedPorts: []string{"9090/udp"},
+						},
+						ManualScaling: &appengine.ManualScaling{
+							Instances: 1,
+						},
+					},
+					// Serving without network.
+					&appengine.Version{
+						Id:            "20181027t210126-inactive",
+						ServingStatus: "SERVING",
+						Network: &appengine.Network{
+							ForwardedPorts: []string{},
+						},
+						ManualScaling: &appengine.ManualScaling{
+							Instances: 1,
+						},
+					},
+					// Not serving.
+					&appengine.Version{
+						Id:            "20181027t210126-inactive",
+						ServingStatus: "STOPPED",
+					},
+				},
+				instances: []*appengine.Instance{
+					// A regular instance.
+					&appengine.Instance{
+						Id:       "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						VmIp:     "192.168.0.2",
+						VmStatus: "RUNNING",
+					},
+					// Missing VmIp.
+					&appengine.Instance{
+						Id:       "aef-etl--sidestream--parser-20181027t210126-x2qi",
+						VmIp:     "",
+						VmStatus: "RUNNING",
+					},
+					// VM is stopped.
+					&appengine.Instance{
+						Id:       "aef-etl--sidestream--parser-20181027t210126-x2qj",
+						VmIp:     "192.168.0.2",
+						VmStatus: "STOPPED",
+					},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.0.2:9090"},
+					Labels: map[string]string{
+						"__aef_public_protocol":     "udp",
+						"__aef_project":             "fake-project",
+						"__aef_service":             "fake-service-name",
+						"__aef_version":             "20181027t210126-active",
+						"__aef_instance":            "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						"__aef_max_total_instances": "1",
+						"__aef_vm_debug_enabled":    "false",
+					},
+				},
+			},
+		},
+		{
+			name:    "success-both-automatic",
+			project: "fake-project",
+			api: &fakeAppAPIImpl{
+				services: []*appengine.Service{
+					&appengine.Service{
+						Id: "fake-service-name",
+						Split: &appengine.TrafficSplit{
+							Allocations: map[string]float64{
+								"20181027t210126-active": 1.0,
+							},
+						},
+					},
+				},
+				versions: []*appengine.Version{
+					&appengine.Version{
+						Id:            "20181027t210126-active",
+						ServingStatus: "SERVING",
+						// When not specifying the protocol, "both" is expected.
+						Network: &appengine.Network{
+							ForwardedPorts: []string{"9090"},
+						},
+						AutomaticScaling: &appengine.AutomaticScaling{
+							MaxTotalInstances: 1,
+						},
+					},
+				},
+				instances: []*appengine.Instance{
+					&appengine.Instance{
+						Id:       "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						VmIp:     "192.168.0.2",
+						VmStatus: "RUNNING",
+					},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.0.2:9090"},
+					Labels: map[string]string{
+						"__aef_public_protocol":     "both",
+						"__aef_project":             "fake-project",
+						"__aef_service":             "fake-service-name",
+						"__aef_version":             "20181027t210126-active",
+						"__aef_instance":            "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						"__aef_max_total_instances": "1",
+						"__aef_vm_debug_enabled":    "false",
+					},
+				},
+			},
+		},
+		{
+			name:    "success-tcp-automatic",
+			project: "fake-project",
+			api: &fakeAppAPIImpl{
+				services: []*appengine.Service{
+					&appengine.Service{
+						Id: "fake-service-name",
+						Split: &appengine.TrafficSplit{
+							Allocations: map[string]float64{
+								"20181027t210126-active": 1.0,
+							},
+						},
+					},
+				},
+				versions: []*appengine.Version{
+					&appengine.Version{
+						Id:            "20181027t210126-active",
+						ServingStatus: "SERVING",
+						Network: &appengine.Network{
+							ForwardedPorts: []string{"9090/tcp"},
+						},
+						AutomaticScaling: &appengine.AutomaticScaling{
+							MaxTotalInstances: 1,
+						},
+					},
+					// Missing network.
+					&appengine.Version{
+						Id:            "20160000t210126-inactive",
+						ServingStatus: "SERVING",
+					},
+				},
+				instances: []*appengine.Instance{
+					&appengine.Instance{
+						Id:       "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						VmIp:     "192.168.0.2",
+						VmStatus: "RUNNING",
+					},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.0.2:9090"},
+					Labels: map[string]string{
+						"__aef_public_protocol":     "tcp",
+						"__aef_project":             "fake-project",
+						"__aef_service":             "fake-service-name",
+						"__aef_version":             "20181027t210126-active",
+						"__aef_instance":            "aef-etl--sidestream--parser-20181027t210126-x2qh",
+						"__aef_max_total_instances": "1",
+						"__aef_vm_debug_enabled":    "false",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &Service{
+				project: tt.project,
+				api:     tt.api,
+				targets: tt.targets,
+			}
+			got, err := source.Discover(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Service.Discover() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Service.Discover() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewService(t *testing.T) {
+	tests := []struct {
+		name       string
+		project    string
+		fakeCreds  bool
+		forceError bool
+		wantErr    bool
+	}{
+		{
+			name:    "success",
+			project: "fake-prject",
+		},
+		{
+			name:      "failure-auth",
+			project:   "fake-prject",
+			fakeCreds: true,
+			wantErr:   true,
+		},
+		{
+			name:       "failure-client",
+			project:    "fake-prject",
+			forceError: true,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.fakeCreds {
+				os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/not-a-real-file")
+				defer func() {
+					os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+				}()
+			}
+			if tt.forceError {
+				origFunc := newAppengineClient
+				newAppengineClient = func(client *http.Client) (*appengine.APIService, error) {
+					return nil, fmt.Errorf("Failing to create client")
+				}
+				defer func() {
+					newAppengineClient = origFunc
+				}()
+			}
+			_, err := NewService(tt.project)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewService() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/aeflex/iface/appapi.go
+++ b/aeflex/iface/appapi.go
@@ -1,0 +1,51 @@
+// Package iface defines an interface for accessing AppEngine APIs. This is
+// helpful for creating testable packages.
+package iface
+
+import (
+	"context"
+
+	appengine "google.golang.org/api/appengine/v1"
+)
+
+// AppAPI defines the interface used by the aeflex logic.
+type AppAPI interface {
+	ServicesPages(ctx context.Context, f func(listVer *appengine.ListServicesResponse) error) error
+	VersionsPages(ctx context.Context, serviceID string, f func(listVer *appengine.ListVersionsResponse) error) error
+	InstancesPages(ctx context.Context, serviceID, versionID string, f func(listInst *appengine.ListInstancesResponse) error) error
+}
+
+// AppAPIImpl implements the AppAPI interface.
+type AppAPIImpl struct {
+	project string
+	apis    *appengine.APIService
+}
+
+// NewAppAPI creates a new instance of the AppAPI for the given project.
+func NewAppAPI(project string, apis *appengine.APIService) *AppAPIImpl {
+	return &AppAPIImpl{project: project, apis: apis}
+}
+
+// ServicesPages lists all AppEngine services and calls the given function for
+// each "page" of results.
+func (a *AppAPIImpl) ServicesPages(
+	ctx context.Context, f func(listVer *appengine.ListServicesResponse) error) error {
+	return a.apis.Apps.Services.List(a.project).Pages(ctx, f)
+}
+
+// VersionsPages lists all AppEngine versions for the given service and calls
+// the given function for each "page" of results.
+func (a *AppAPIImpl) VersionsPages(
+	ctx context.Context, serviceID string,
+	f func(listVer *appengine.ListVersionsResponse) error) error {
+	return a.apis.Apps.Services.Versions.List(a.project, serviceID).Pages(ctx, f)
+}
+
+// InstancesPages lists all AppEngine instances for the given service and
+// version and calls the given function for each "page" of results.
+func (a *AppAPIImpl) InstancesPages(
+	ctx context.Context, serviceID, versionID string,
+	f func(listInst *appengine.ListInstancesResponse) error) error {
+	return a.apis.Apps.Services.Versions.Instances.List(
+		a.project, serviceID, versionID).Pages(ctx, f)
+}

--- a/cmd/gcp_service_discovery/main.go
+++ b/cmd/gcp_service_discovery/main.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/m-lab/go/rtx"
+
 	flag "github.com/spf13/pflag"
 
 	"github.com/m-lab/gcp-service-discovery/aeflex"
@@ -65,7 +67,9 @@ func main() {
 	// Allocate every relevant source factories.
 	if *aefTarget != "" {
 		// Allocate a new authenticated client for App Engine API.
-		factories = append(factories, aeflex.NewSourceFactory(*project, *aefTarget))
+		s, err := aeflex.NewService(*project)
+		rtx.Must(err, "Failed to create an aeflex.Service for project: %q", *project)
+		manager.Register(s, *aefTarget)
 	}
 	if *gkeTarget != "" {
 		// Allocate a new authenticated client for GCE & GKE API.


### PR DESCRIPTION
This change updates the aeflex package to implement the new `discovery.Service` interface and adds unit testing for the same package. To facilitate unit testing, this change adds a subpackage to aeflex that defines the `iface.AppAPI` interface with a simple implementation that wraps otherwise untestable calls to AppEngine APIs. The wrapper logic in the `iface` package is so simple that it should be "correct by inspection".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/19)
<!-- Reviewable:end -->
