### PR TITLE
Add unit tests for gke service discovery 

### DIFF
--- a/cmd/gcp_service_discovery/main.go
+++ b/cmd/gcp_service_discovery/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 	if *gkeTarget != "" {
 		// Allocate a new authenticated client for GCE & GKE API.
-		s := gke.NewServiceMust(*project)
+		s := gke.MustNewService(*project)
 		manager.Register(s, *gkeTarget)
 	}
 	for i := range httpSources {

--- a/gke/gke.go
+++ b/gke/gke.go
@@ -48,7 +48,8 @@ type Service struct {
 	cache string
 }
 
-// NewService create a new GKE service discovery instance.
+// NewServiceMust creates a new GKE service discovery instance. The function
+// exits if an error occurs during setup.
 func NewServiceMust(project string) *Service {
 	var err error
 

--- a/gke/gke.go
+++ b/gke/gke.go
@@ -23,8 +23,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
-	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"github.com/m-lab/gcp-service-discovery/discovery"
 )
 
@@ -48,9 +46,9 @@ type Service struct {
 	cache string
 }
 
-// NewServiceMust creates a new GKE service discovery instance. The function
+// MustNewService creates a new GKE service discovery instance. The function
 // exits if an error occurs during setup.
-func NewServiceMust(project string) *Service {
+func MustNewService(project string) *Service {
 	var err error
 
 	s := &Service{

--- a/gke/gke.go
+++ b/gke/gke.go
@@ -152,7 +152,7 @@ func checkCluster(k kubernetes.Interface, zoneName, clusterName string) ([]disco
 		if service.ObjectMeta.Annotations["gke-prometheus-federation/scrape"] != "true" {
 			continue
 		}
-		target := findTargetAndLables(zoneName, clusterName, service)
+		target := findTargetAndLabels(zoneName, clusterName, service)
 		if target != nil {
 			configs = append(configs, *target)
 		}
@@ -160,9 +160,9 @@ func checkCluster(k kubernetes.Interface, zoneName, clusterName string) ([]disco
 	return configs, nil
 }
 
-// findTargetAndLables identifies the first target (first port) per service and
+// findTargetAndLabels identifies the first target (first port) per service and
 // returns a target configuration for use with Prometheus file service discovery.
-func findTargetAndLables(zoneName, clusterName string, service typesv1.Service) *discovery.StaticConfig {
+func findTargetAndLabels(zoneName, clusterName string, service typesv1.Service) *discovery.StaticConfig {
 	var target string
 
 	if len(service.Spec.ExternalIPs) > 0 && len(service.Spec.Ports) > 0 {

--- a/gke/gke.go
+++ b/gke/gke.go
@@ -1,16 +1,17 @@
-// gke implements service discovery for GKE clusters with k8s services annotated
-// for federation scraping.
+// Package gke implements service discovery for GKE clusters with k8s services annotated
+// for federation collection.
 package gke
 
 import (
+	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 
-	"github.com/dchest/safefile"
-	"github.com/kr/pretty"
+	"github.com/m-lab/go/rtx"
+
+	"github.com/m-lab/gcp-service-discovery/gke/iface"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -21,6 +22,7 @@ import (
 	typesv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/clientcmd/api"
+
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"github.com/m-lab/gcp-service-discovery/discovery"
@@ -32,144 +34,117 @@ var (
 	gkeScopes = []string{compute.CloudPlatformScope}
 )
 
-// Factory stores information needed to create new Source instances.
-type Factory struct {
+// Service contains necessary data for service discovery in GKE.
+type Service struct {
 	// The GCP project id.
 	project string
-
-	// The output filename.
-	filename string
-}
-
-// NewSourceFactory returns a new Factory object that can create new GKE Sources.
-func NewSourceFactory(project, filename string) *Factory {
-	return &Factory{
-		project:  project,
-		filename: filename,
-	}
-}
-
-// Create returns a discovery.Source initialized with authenticated clients for
-// Compute & Container APIs, ready for Collection.
-func (f *Factory) Create() (discovery.Source, error) {
-	source := &Source{
-		factory: *f,
-	}
-	var err error
-
-	// Create a new authenticated HTTP client.
-	source.client, err = google.DefaultClient(oauth2.NoContext, gkeScopes...)
-	if err != nil {
-		return nil, fmt.Errorf("Error setting up Compute client: %s", err)
-	}
-
-	// Create a new Compute service instance.
-	source.computeService, err = compute.New(source.client)
-	if err != nil {
-		return nil, fmt.Errorf("Error setting up Compute client: %s", err)
-	}
-
-	// Create a new Container Engine service object.
-	source.containerService, err = container.New(source.client)
-	if err != nil {
-		return nil, fmt.Errorf("Error setting up Container Engine client: %s", err)
-	}
-
-	return source, nil
-}
-
-// Source caches information collected from the GCE, GKE, and K8S APIs during target discovery.
-type Source struct {
-	// factory is a copy of the original instance that created this source.
-	factory Factory
 
 	// client caches an http client authenticated for access to GCP APIs.
 	client *http.Client
 
-	// computeService is the entry point to all GCE services.
-	computeService *compute.Service
+	gke iface.GKE
 
-	// containerService is the entry point to all GKE services.
-	containerService *container.Service
-
-	// targets collects found targets.
-	targets []interface{}
+	// cache is temporary storage to determine whether to update.
+	cache string
 }
 
-// Saves collected targets to the given filename.
-func (source *Source) Save() error {
-	// Convert the targets to JSON.
-	data, err := json.MarshalIndent(source.targets, "", "    ")
-	if err != nil {
-		log.Printf("Failed to Marshal JSON: %s", err)
-		log.Printf("Pretty data: %s", pretty.Sprint(source.targets))
-		return err
-	}
+// NewService create a new GKE service discovery instance.
+func NewServiceMust(project string) *Service {
+	var err error
 
-	// Save targets to output file.
-	log.Printf("Saving: %s", source.factory.filename)
-	err = safefile.WriteFile(source.factory.filename, data, 0644)
-	if err != nil {
-		log.Printf("Failed to write %s: %s", source.factory.filename, err)
-		return err
+	s := &Service{
+		project: project,
 	}
-	return nil
+	// Create a new authenticated HTTP client.
+	s.client, err = google.DefaultClient(oauth2.NoContext, gkeScopes...)
+	rtx.Must(err, "Error setting up default client")
+
+	// Create a new Compute service instance.
+	computeService, err := compute.New(s.client)
+	rtx.Must(err, "Error setting up a Compute API client")
+
+	// Create a new Container Engine service object.
+	containerService, err := container.New(s.client)
+	rtx.Must(err, "Error setting up a Container API client")
+
+	s.gke = iface.NewGKE(project, computeService, containerService, getKubeClient)
+	return s
 }
 
-// Collect uses the Compute Engine, Container Engine, and Kubernetes APIs to
+// Discover uses the Compute Engine, Container Engine, and Kubernetes APIs to
 // check every GCE zone for Container Engine (gke) clusters, and checks each
 // cluster for services annotated for federated scraping.
 //
 // Collect returns every gke cluster with a k8s service annotation that equals:
 //    gke-prometheus-federation/scrape: true
-func (source *Source) Collect() error {
-	// Allocate space for the list of targets.
-	source.targets = make([]interface{}, 0)
+func (s *Service) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
+	targets := []discovery.StaticConfig{}
 
 	// Get all zones in a project.
-	zoneListCall := source.computeService.Zones.List(source.factory.project)
-	err := zoneListCall.Pages(nil, func(zones *compute.ZoneList) error {
+	zones, err := s.getZoneList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, zone := range zones {
+		t, err := s.findTargetsFromZone(ctx, zone)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, t...)
+	}
+	return targets, err
+}
+
+func (s *Service) getZoneList(ctx context.Context) ([]string, error) {
+	zoneNames := []string{}
+	err := s.gke.ZonePages(ctx, func(zones *compute.ZoneList) error {
 		for _, zone := range zones.Items {
-
-			// Get all clusters in a zone.
-			clusterList, err := source.containerService.Projects.Zones.Clusters.List(
-				source.factory.project, zone.Name).Do()
-			if err != nil {
-				return err
-			}
-
-			// Look for targets from every cluster.
-			for _, cluster := range clusterList.Clusters {
-				targets, err := checkCluster(zone, cluster)
-				if err != nil {
-					return err
-				}
-				source.targets = append(source.targets, targets...)
-			}
+			zoneNames = append(zoneNames, zone.Name)
 		}
 		return nil
 	})
-	// TODO(p2, soltesz): consider using goroutines to speed up collection.
-	return err
+	return zoneNames, err
 }
 
-// checkCluster uses the kubernetes API to search for GKE targets.
-func checkCluster(zone *compute.Zone, cluster *container.Cluster) ([]interface{}, error) {
-	targets := []interface{}{}
-	// Use information from the GKE cluster to create a k8s API client.
-	kubeClient, err := gkeClusterToKubeClient(cluster)
+func (s *Service) findTargetsFromZone(ctx context.Context, zoneName string) ([]discovery.StaticConfig, error) {
+	targets := []discovery.StaticConfig{}
+
+	// Get all clusters in a zone.
+	clusters, err := s.gke.ClusterList(ctx, zoneName)
 	if err != nil {
 		return nil, err
 	}
 
+	// Look for targets from every cluster.
+	for _, cluster := range clusters.Clusters {
+		// Use information from the GKE cluster to create a k8s API client.
+
+		// TODO: consider using new interface, like getKubeClient(cluster *container.Cluster)
+		kubeClient, err := s.gke.GetKubeClient(cluster)
+		if err != nil {
+			return nil, err
+		}
+		t, err := checkCluster(kubeClient, zoneName, cluster.Name)
+		if err != nil {
+			return nil, err
+		}
+		targets = append(targets, t...)
+	}
+	return targets, nil
+}
+
+// checkCluster uses the kubernetes API to search for GKE targets.
+func checkCluster(k kubernetes.Interface, zoneName, clusterName string) ([]discovery.StaticConfig, error) {
+	configs := []discovery.StaticConfig{}
+
 	// List all services in the k8s cluster.
-	services, err := kubeClient.CoreV1().Services("").List(metav1.ListOptions{})
+	services, err := k.CoreV1().Services("").List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	log.Printf("%s - %s - There are %d services in the cluster\n",
-		zone.Name, cluster.Name, len(services.Items))
+		zoneName, clusterName, len(services.Items))
 
 	// Check each service, and collect targets that have matching annotations.
 	for _, service := range services.Items {
@@ -177,17 +152,17 @@ func checkCluster(zone *compute.Zone, cluster *container.Cluster) ([]interface{}
 		if service.ObjectMeta.Annotations["gke-prometheus-federation/scrape"] != "true" {
 			continue
 		}
-		values := findTargetAndLables(zone, cluster, service)
-		if values != nil {
-			targets = append(targets, values)
+		target := findTargetAndLables(zoneName, clusterName, service)
+		if target != nil {
+			configs = append(configs, *target)
 		}
 	}
-	return targets, nil
+	return configs, nil
 }
 
 // findTargetAndLables identifies the first target (first port) per service and
 // returns a target configuration for use with Prometheus file service discovery.
-func findTargetAndLables(zone *compute.Zone, cluster *container.Cluster, service typesv1.Service) interface{} {
+func findTargetAndLables(zoneName, clusterName string, service typesv1.Service) *discovery.StaticConfig {
 	var target string
 
 	if len(service.Spec.ExternalIPs) > 0 && len(service.Spec.Ports) > 0 {
@@ -216,20 +191,19 @@ func findTargetAndLables(zone *compute.Zone, cluster *container.Cluster, service
 	if target == "" {
 		return nil
 	}
-	values := map[string]interface{}{
-		"labels": map[string]string{
+	return &discovery.StaticConfig{
+		Targets: []string{target},
+		Labels: map[string]string{
 			"service": service.ObjectMeta.Name,
-			"cluster": cluster.Name,
-			"zone":    zone.Name,
+			"cluster": clusterName,
+			"zone":    zoneName,
 		},
-		"targets": []string{target},
 	}
-	return values
 }
 
-// gkeClusterToKubeClient converts a container engine API Cluster object into
+// getKubeClient converts a container engine API Cluster object into
 // a kubernetes API client instance.
-func gkeClusterToKubeClient(c *container.Cluster) (*kubernetes.Clientset, error) {
+func getKubeClient(c *container.Cluster) (kubernetes.Interface, error) {
 	// The cluster CA certificate is base64 encoded from the GKE API.
 	rawCaCert, err := base64.URLEncoding.DecodeString(c.MasterAuth.ClusterCaCertificate)
 	if err != nil {
@@ -244,7 +218,7 @@ func gkeClusterToKubeClient(c *container.Cluster) (*kubernetes.Clientset, error)
 	clusterClient := api.Config{
 		Clusters: map[string]*api.Cluster{
 			// Define the cluster address and CA Certificate.
-			"cluster": &api.Cluster{
+			"cluster": {
 				Server:                   fmt.Sprintf("https://%s", c.Endpoint),
 				InsecureSkipTLSVerify:    false, // Require a valid CA Certificate.
 				CertificateAuthorityData: rawCaCert,
@@ -252,14 +226,14 @@ func gkeClusterToKubeClient(c *container.Cluster) (*kubernetes.Clientset, error)
 		},
 		AuthInfos: map[string]*api.AuthInfo{
 			// Define the user credentials for access to the API.
-			"user": &api.AuthInfo{
+			"user": {
 				Username: c.MasterAuth.Username,
 				Password: c.MasterAuth.Password,
 			},
 		},
 		Contexts: map[string]*api.Context{
 			// Define a context that refers to the above cluster and user.
-			"cluster-user": &api.Context{
+			"cluster-user": {
 				Cluster:  "cluster",
 				AuthInfo: "user",
 			},
@@ -268,10 +242,13 @@ func gkeClusterToKubeClient(c *container.Cluster) (*kubernetes.Clientset, error)
 		CurrentContext: "cluster-user",
 	}
 
-	// TODO: what is this?
-	restConfig, err := clientcmd.NewDefaultClientConfig(
-		clusterClient, &clientcmd.ConfigOverrides{
-			ClusterInfo: api.Cluster{Server: ""}}).ClientConfig()
+	// Construct a "direct client" using the auth above to contact the API server.
+	defClient := clientcmd.NewDefaultClientConfig(
+		clusterClient,
+		&clientcmd.ConfigOverrides{
+			ClusterInfo: api.Cluster{Server: ""},
+		})
+	restConfig, err := defClient.ClientConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/gke/gke_test.go
+++ b/gke/gke_test.go
@@ -1,5 +1,3 @@
-// gke implements service discovery for GKE clusters with k8s services annotated
-// for federation scraping.
 package gke
 
 import (
@@ -51,21 +49,7 @@ func (f *fakeGKEImpl) GetKubeClient(c *container.Cluster) (kubernetes.Interface,
 }
 
 func TestMustNewService(t *testing.T) {
-	tests := []struct {
-		name    string
-		project string
-		want    *Service
-	}{
-		{
-			name:    "success",
-			project: "fake-project",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_ = MustNewService(tt.project)
-		})
-	}
+	_ = MustNewService("fake-project")
 }
 
 func TestService_Discover(t *testing.T) {

--- a/gke/gke_test.go
+++ b/gke/gke_test.go
@@ -1,0 +1,266 @@
+// gke implements service discovery for GKE clusters with k8s services annotated
+// for federation scraping.
+package gke
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/m-lab/gcp-service-discovery/discovery"
+	compute "google.golang.org/api/compute/v1"
+	container "google.golang.org/api/container/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func Test_checkCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		Interface   kubernetes.Interface
+		service     apiv1.Service
+		zoneName    string
+		clusterName string
+		want        []discovery.StaticConfig
+		wantErr     bool
+	}{
+		{
+			name: "successful-external-ip",
+			service: apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"gke-prometheus-federation/scrape": "true"},
+				},
+				Spec: apiv1.ServiceSpec{
+					Ports:       []apiv1.ServicePort{{Port: 1122}},
+					ExternalIPs: []string{"192.168.1.1"},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.1.1:1122"},
+					Labels:  map[string]string{"zone": "", "service": "", "cluster": ""},
+				},
+			},
+		},
+		{
+			name: "successful-loadbalancer",
+			service: apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"gke-prometheus-federation/scrape": "true"},
+				},
+				Spec: apiv1.ServiceSpec{
+					Ports: []apiv1.ServicePort{{Port: 1122}},
+				},
+				Status: apiv1.ServiceStatus{
+					LoadBalancer: apiv1.LoadBalancerStatus{
+						Ingress: []apiv1.LoadBalancerIngress{{IP: "192.168.1.1"}},
+					},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.1.1:1122"},
+					Labels:  map[string]string{"zone": "", "service": "", "cluster": ""},
+				},
+			},
+		},
+		{
+			name: "failure-skipping-annotation",
+			service: apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"gke-prometheus-federation/scrape": "false"},
+				},
+			},
+			want: []discovery.StaticConfig{},
+		},
+		{
+			name: "failure-empty-target",
+			service: apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"gke-prometheus-federation/scrape": "true"},
+				},
+			},
+			want: []discovery.StaticConfig{},
+		},
+		{
+			name:    "failure-service-list-error",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := fake.NewSimpleClientset()
+			i.Fake.PrependReactor("list", "services", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				if tt.wantErr {
+					return true, nil, fmt.Errorf("Fake error")
+				}
+				return true, &apiv1.ServiceList{Items: []apiv1.Service{tt.service}}, nil
+			})
+			got, err := checkCluster(i, tt.zoneName, tt.clusterName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("kubeOps.checkCluster() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("kubeOps.checkCluster() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getKubeClient(t *testing.T) {
+	tests := []struct {
+		name    string
+		c       *container.Cluster
+		want    *kubernetes.Clientset
+		wantErr bool
+	}{
+		{
+			name: "success",
+			c: &container.Cluster{
+				MasterAuth: &container.MasterAuth{
+					ClusterCaCertificate: "",
+				},
+				Endpoint: "https://localhost:6443",
+			},
+		},
+		{
+			name: "failure-parsing-certificate",
+			c: &container.Cluster{
+				MasterAuth: &container.MasterAuth{
+					ClusterCaCertificate: ":::::invalid:::::",
+				},
+				Endpoint: "https://localhost:6443",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := getKubeClient(tt.c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("gkeClusterToKubeClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func TestNewServiceMust(t *testing.T) {
+	tests := []struct {
+		name    string
+		project string
+		want    *Service
+	}{
+		{
+			name:    "success",
+			project: "fake-project",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_ = NewServiceMust(tt.project)
+		})
+	}
+}
+
+type fakeGKEImpl struct {
+	project   string
+	zones     *compute.ZoneList
+	clusters  *container.ListClustersResponse
+	Interface kubernetes.Interface
+}
+
+func (f *fakeGKEImpl) ZonePages(ctx context.Context, pageFunc func(zones *compute.ZoneList) error) error {
+	return pageFunc(f.zones)
+}
+
+// ClusterList ...
+func (f *fakeGKEImpl) ClusterList(ctx context.Context, zone string) (*container.ListClustersResponse, error) {
+	return f.clusters, nil
+}
+
+func (f *fakeGKEImpl) GetKubeClient(c *container.Cluster) (kubernetes.Interface, error) {
+	return f.Interface, nil
+}
+
+func TestService_Discover(t *testing.T) {
+	fgke := &fakeGKEImpl{
+		project: "fake-project",
+		zones: &compute.ZoneList{
+			Items: []*compute.Zone{
+				{Name: "us-central1-z"},
+			},
+		},
+		clusters: &container.ListClustersResponse{
+			Clusters: []*container.Cluster{
+				&container.Cluster{
+					Name: "fake-cluster",
+					MasterAuth: &container.MasterAuth{
+						ClusterCaCertificate: "",
+					},
+					Endpoint: "https://localhost:6443",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		project string
+		gke     *fakeGKEImpl
+		service apiv1.Service
+		ctx     context.Context
+		want    []discovery.StaticConfig
+		wantErr bool
+	}{
+		{
+			name:    "success",
+			project: "fake-project",
+			gke:     fgke,
+			service: apiv1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"gke-prometheus-federation/scrape": "true"},
+				},
+				Spec: apiv1.ServiceSpec{
+					Ports:       []apiv1.ServicePort{{Port: 1122}},
+					ExternalIPs: []string{"192.168.1.1"},
+				},
+			},
+			want: []discovery.StaticConfig{
+				{
+					Targets: []string{"192.168.1.1:1122"},
+					Labels:  map[string]string{"zone": "us-central1-z", "service": "", "cluster": "fake-cluster"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := fake.NewSimpleClientset()
+			i.Fake.PrependReactor("list", "services", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, &apiv1.ServiceList{Items: []apiv1.Service{tt.service}}, nil
+			})
+			tt.gke.Interface = i
+			s := &Service{
+				project: tt.project,
+				gke:     tt.gke,
+			}
+			got, err := s.Discover(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Service.Discover() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Service.Discover() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gke/iface/gkeapi.go
+++ b/gke/iface/gkeapi.go
@@ -1,3 +1,6 @@
+// Package iface defines an interface for accessing Google Compute & Container
+// APIs, and helps mediate access to k8s clients. This is helpful for creating
+// testable packages.
 package iface
 
 import (

--- a/gke/iface/gkeapi.go
+++ b/gke/iface/gkeapi.go
@@ -1,0 +1,46 @@
+package iface
+
+import (
+	"context"
+
+	compute "google.golang.org/api/compute/v1"
+	container "google.golang.org/api/container/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GKE defines the interface used by the gke logic.
+type GKE interface {
+	ZonePages(ctx context.Context, f func(zones *compute.ZoneList) error) error
+	ClusterList(ctx context.Context, zone string) (*container.ListClustersResponse, error)
+	GetKubeClient(c *container.Cluster) (kubernetes.Interface, error)
+}
+
+// GKEImpl implements the GKE interface.
+type GKEImpl struct {
+	project          string
+	computeService   *compute.Service
+	containerService *container.Service
+	getKubeClient    func(c *container.Cluster) (kubernetes.Interface, error)
+}
+
+// NewGKE creates a new GKE instance.
+func NewGKE(project string, compute *compute.Service, container *container.Service,
+	getKubeClient func(c *container.Cluster) (kubernetes.Interface, error)) *GKEImpl {
+	return &GKEImpl{project: project, computeService: compute,
+		containerService: container, getKubeClient: getKubeClient}
+}
+
+// ZonePages wraps the computeService Zones.List().Pages method.
+func (g *GKEImpl) ZonePages(ctx context.Context, f func(zones *compute.ZoneList) error) error {
+	return g.computeService.Zones.List(g.project).Pages(ctx, f)
+}
+
+// ClusterList wraps the container service Clusters.List method for the given zone.
+func (g *GKEImpl) ClusterList(ctx context.Context, zone string) (*container.ListClustersResponse, error) {
+	return g.containerService.Projects.Zones.Clusters.List(g.project, zone).Context(ctx).Do()
+}
+
+// GetKubeClient returns a kubernetes interface for the given cluster.
+func (g *GKEImpl) GetKubeClient(c *container.Cluster) (kubernetes.Interface, error) {
+	return g.getKubeClient(c)
+}


### PR DESCRIPTION
This change updates the gke package to implement the new discovery.Service interface and adds unit testing for the same package. To facilitate unit testing, this change adds a subpackage to gke that defines the iface.GKE interface with a simple implementation that wraps otherwise untestable calls to Google Compute & Container APIs. The wrapper logic in the iface package is so simple that it should be "correct by inspection".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/20)
<!-- Reviewable:end -->
