### PR TITLE
Make a really static binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.11 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
-RUN go get -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery
+RUN CGO_ENABLED=0 go get -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery
 
 # Now copy the built image into the minimal base image
 FROM alpine


### PR DESCRIPTION
This change fixes a bug in the gcp-service-discovery Dockerfile that results in an unrunnable binary by creating a truly static binary. This change will unblock https://github.com/m-lab/prometheus-support/pull/397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/24)
<!-- Reviewable:end -->
