### PR TITLE
Add ca certificates to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN CGO_ENABLED=0 go get -v github.com/m-lab/gcp-service-discovery/cmd/gcp_servi
 # Now copy the built image into the minimal base image
 FROM alpine
 COPY --from=build /go/bin/gcp_service_discovery /
-# Instal ca-certificates so the gcp_service_discovery process can contact TLS
+# Install ca-certificates so the gcp_service_discovery process can contact TLS
 # services securely.
 RUN apk update && apk add ca-certificates
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,8 @@ RUN CGO_ENABLED=0 go get -v github.com/m-lab/gcp-service-discovery/cmd/gcp_servi
 # Now copy the built image into the minimal base image
 FROM alpine
 COPY --from=build /go/bin/gcp_service_discovery /
+# Instal ca-certificates so the gcp_service_discovery process can contact TLS
+# services securely.
+RUN apk update && apk add ca-certificates
 WORKDIR /
 ENTRYPOINT ["/gcp_service_discovery"]


### PR DESCRIPTION
In order to contact services securely, the gcp-service-discovery image needs to include the ca-certificates package. This PR adds it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/25)
<!-- Reviewable:end -->
