### PR TITLE
Prevent cached results and add test to check for error

### DIFF
--- a/aeflex/aeflex.go
+++ b/aeflex/aeflex.go
@@ -116,6 +116,7 @@ func NewService(project string) (*Service, error) {
 func (source *Service) Discover(ctx context.Context) ([]discovery.StaticConfig, error) {
 	// List all services.
 	services := 0
+	source.targets = []discovery.StaticConfig{}
 	err := source.api.ServicesPages(
 		ctx, func(listSvc *appengine.ListServicesResponse) error {
 			services += len(listSvc.Services)

--- a/aeflex/aeflex_test.go
+++ b/aeflex/aeflex_test.go
@@ -289,6 +289,15 @@ func TestService_Discover(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Service.Discover() = %v, want %v", got, tt.want)
 			}
+			// Call Discover again, to verify it returns the same set of targets.
+			got2, err := source.Discover(tt.ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Service.Discover() error = %v", err)
+				return
+			}
+			if !reflect.DeepEqual(got, got2) {
+				t.Errorf("Service.Discover() = %v, want %v", got, got2)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change fixes a bug discovered in staging yesterday. The aeflex service discovery was accidentally caching previous results, re-adding new ones, and preventing old targets from ever being removed.

This change fixes that bug and adds a new unit test to prevent a similar mistake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/28)
<!-- Reviewable:end -->
