### PR TITLE
Add -max-discovery flag & discovery metrics

### DIFF
--- a/discovery/manager.go
+++ b/discovery/manager.go
@@ -5,11 +5,55 @@ package discovery
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/dchest/safefile"
 	"github.com/m-lab/go/rtx"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// discoveryDurationHist provides a histogram of the time to run service discovery.
+	// The metric is labeled by the output filename, which is unique for each service.
+	//
+	// Provides metrics:
+	//   gcp_manager_discovery_seconds_bucket
+	//   gcp_manager_discovery_seconds_count
+	//   gcp_manager_discovery_seconds_sum
+	// Usage example:
+	//   discoveryDurationHist.WithLabelValues("aeflex.Service").Observe(tDiff)
+	discoveryDurationHist = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "gcp_manager_discovery_seconds",
+			Help: "Histogram of service discovery run times.",
+			Buckets: []float64{
+				10, 15, 25, 40, 60,
+				100, 150, 250, 400, 600,
+				1000, 1500, 2500, 4000, 6000,
+			},
+		},
+		[]string{"service"},
+	)
+
+	// discoveryTotal counts the total number of calls to service discovery. The
+	// metric is labeled by the output filename and whether the discovery succeeded
+	// or failed.
+	//
+	// Provides metrics:
+	//   gcp_manager_discovery_total
+	// Usage example:
+	//   discoveryTotal.WithLabelValues("aeflex.Service", "success").Inc()
+	discoveryTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gcp_manager_discovery_total",
+			Help: "Number of discovery runs.",
+		},
+		[]string{"service", "status"},
+	)
 )
 
 // Manager executes service discovery then serializes and writes targets to disk.
@@ -45,18 +89,24 @@ func (m *Manager) Run(ctx context.Context, interval time.Duration) {
 	for {
 		// TODO: add waitgroup and run discovery in parallel.
 		for i := range m.services {
-
+			service := strings.TrimPrefix(fmt.Sprintf("%T", m.services[i]), "*")
+			t0 := time.Now()
 			disCtx, cancel := context.WithTimeout(ctx, m.Timeout)
 			configs, err := m.services[i].Discover(disCtx)
 			cancel()
 			if err != nil {
 				log.Printf("Error: %T: %s", m.services[i], err)
+				discoveryTotal.WithLabelValues(service, "error-discovery").Inc()
 				continue
 			}
+			discoveryDurationHist.WithLabelValues(service).Observe(time.Since(t0).Seconds())
 			err = writeConfigToFile(configs, m.output[i])
 			if err != nil {
 				log.Printf("Error: %s: %s", m.output[i], err)
+				discoveryTotal.WithLabelValues(service, "error-write").Inc()
+				continue
 			}
+			discoveryTotal.WithLabelValues(service, "success").Inc()
 		}
 
 		// Wait for ticker or exit when ctx is closed.


### PR DESCRIPTION
This change fixes https://github.com/m-lab/prometheus-support/issues/433

This change also adds new metrics to track discovery run times and discovery success or failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/30)
<!-- Reviewable:end -->
