### PR TITLE
Allow monitoring before serving for the first 20 minutes

### DIFF
--- a/aeflex/aeflex_test.go
+++ b/aeflex/aeflex_test.go
@@ -66,6 +66,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-active",
 				ServingStatus: "SERVING",
+				CreateTime:    "2018-10-27T21:01:26Z",
 			},
 		},
 		instancesError: fmt.Errorf("failing to list instances"),
@@ -86,6 +87,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-active",
 				ServingStatus: "SERVING",
+				CreateTime:    "2018-10-27T21:01:26Z",
 				Network: &appengine.Network{
 					ForwardedPorts: []string{"9090/udp"},
 				},
@@ -97,6 +99,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-inactive",
 				ServingStatus: "SERVING",
+				CreateTime:    "2018-10-27T21:01:26Z",
 				Network: &appengine.Network{
 					ForwardedPorts: []string{},
 				},
@@ -108,6 +111,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-inactive",
 				ServingStatus: "STOPPED",
+				CreateTime:    "2018-10-27T21:01:26Z",
 			},
 		},
 		instances: []*appengine.Instance{
@@ -146,6 +150,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-active",
 				ServingStatus: "SERVING",
+				CreateTime:    "2018-10-27T21:01:26Z",
 				// When not specifying the protocol, "both" is expected.
 				Network: &appengine.Network{
 					ForwardedPorts: []string{"9090"},
@@ -178,6 +183,7 @@ func TestService_Discover(t *testing.T) {
 			{
 				Id:            "20181027t210126-active",
 				ServingStatus: "SERVING",
+				CreateTime:    "2018-10-27T21:01:26Z",
 				Network: &appengine.Network{
 					ForwardedPorts: []string{"9090/tcp"},
 				},
@@ -187,8 +193,15 @@ func TestService_Discover(t *testing.T) {
 			},
 			// Missing network.
 			{
-				Id:            "20160000t210126-inactive",
+				Id:            "20160101t210126-inactive",
 				ServingStatus: "SERVING",
+				CreateTime:    "2016-01-01T21:01:26Z",
+			},
+			// Includes bad format for CreateTime.
+			{
+				Id:            "20160101t210126-inactive",
+				ServingStatus: "SERVING",
+				CreateTime:    "2016-00-01T21:01:26Z", // Invalid month.
 			},
 		},
 		instances: []*appengine.Instance{


### PR DESCRIPTION
For servers that have advanced "warm up" phases, it is helpful to monitor them before they are reported as "SERVING" traffic. This change additionally checks whether each version was created in the last 20min and if so begins monitoring it before it is serving.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/32)
<!-- Reviewable:end -->
