### PR TITLE
Fixes coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ go:
 go_import_path: github.com/m-lab/gcp-service-discovery
 
 before_install:
+- export COVERALLS_SERVICE_JOB_ID=$(TRAVIS_JOB_ID)
+- export COVERALLS_SERVICE_NAME="gcp-service-discovery"
 - go get github.com/mattn/goveralls
 - go get github.com/wadey/gocovmerge
 


### PR DESCRIPTION
Currently, Travis builds are failing with this error:

```
$ $HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci
bad response status from coveralls: 422
{"message":"service_job_id (527207983) must be unique for Travis Jobs not supplying a Coveralls Repo Token","error":true}
The command "$HOME/gopath/bin/goveralls -coverprofile=merge.cov -service=travis-ci" exited with 1.
```

This PR fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/36)
<!-- Reviewable:end -->
