### PR TITLE
Update go version to 1.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: focal
+
 language: go
 
 go:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.20.7
+- 1.18
 
 # Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
 go_import_path: github.com/m-lab/gcp-service-discovery

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
 - sudo apt-get update
-- sudo apt-get install docker-engine
+- sudo apt-get install docker-ce
 
 script:
 # Run query "unit tests".

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ before_install:
 - export COVERALLS_SERVICE_NAME="gcp-service-discovery"
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
-- curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-- sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-- sudo apt-get update
-- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 script:
 - docker version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
 - export COVERALLS_SERVICE_NAME="gcp-service-discovery"
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
+- sudo apt-get update
+- sudo apt-get install docker-engine
 
 script:
 # Run query "unit tests".

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.18
+- 1.20
 
 # Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
 go_import_path: github.com/m-lab/gcp-service-discovery

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ before_install:
 - go install github.com/wadey/gocovmerge@latest
 
 script:
-- docker version
 # Run query "unit tests".
 - go test -v -short -covermode=count -coverprofile=merge.cov ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,13 @@ before_install:
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
 script:
+- docker version
 # Run query "unit tests".
 - go test -v -short -covermode=count -coverprofile=merge.cov ./...
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ before_install:
 - export COVERALLS_SERVICE_NAME="gcp-service-discovery"
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
-
-addons:
-  apt:
-    packages:
-      - docker-ce
+- curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+- sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+- sudo apt-get update
+- sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
 
 script:
 - docker version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.20
+- 1.20.7
 
 # Place the repo at GOPATH/src/${go_import_path} to support PRs from forks.
 go_import_path: github.com/m-lab/gcp-service-discovery
@@ -11,8 +11,6 @@ before_install:
 - export COVERALLS_SERVICE_NAME="gcp-service-discovery"
 - go install github.com/mattn/goveralls@latest
 - go install github.com/wadey/gocovmerge@latest
-- sudo apt-get update
-- sudo apt-get install docker-ce
 
 script:
 # Run query "unit tests".

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.18 as build
+FROM golang:1.20 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
-RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
+RUN CGO_ENABLED=0 --security-opt seccomp=unconfined go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 
 # Now copy the built image into the minimal base image
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7 as build
+FROM golang:1.20 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
 RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.20 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
-RUN CGO_ENABLED=0 --security-opt seccomp=unconfined go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
+RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 
 # Now copy the built image into the minimal base image
 FROM alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18 as build
+FROM golang:1.20 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
 RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build
+FROM golang:1.20.7 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
 RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20 as build
+FROM golang:1.18 as build
 COPY . /go/src/github.com/m-lab/gcp-service-discovery
 RUN CGO_ENABLED=0 go install -v github.com/m-lab/gcp-service-discovery/cmd/gcp_service_discovery@latest
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/m-lab/gcp-service-discovery
 
-go 1.18
+go 1.20
 
 require (
 	github.com/dchest/safefile v0.0.0-20151022103144-855e8d98f185


### PR DESCRIPTION
The PR also updates the Linux distribution to Focal because the default (Xenial) has an older version of Docker, which throws a CGO exception `runtime/cgo: pthread_create failed: Operation not permitted`.

Part of https://github.com/m-lab/dev-tracker/issues/771
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/gcp-service-discovery/43)
<!-- Reviewable:end -->
